### PR TITLE
add basic unary ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/andrew-johnson-4/L1IR"
 keywords = ["compiler","interpreter","AST","IR","JIT"]
 
 [dependencies]
+num-bigint = { version = "0.4" }
 cranelift = { version = "0.91", optional = true }
 cranelift-module = { version = "0.91", optional = true }
 cranelift-jit = { version = "0.91", optional = true }

--- a/tests/a_eq.rs
+++ b/tests/a_eq.rs
@@ -2,6 +2,42 @@ use std::rc::Rc;
 use l1_ir::ast::{Value};
 
 #[test]
+fn eq_unary() {
+   assert_eq!(
+      Value::unary(b"0"),
+      Value::unary(b"0"),
+   );
+   assert_eq!(
+      Value::unary(b"1"),
+      Value::unary(b"1"),
+   );
+   assert_eq!(
+      Value::unary(b"123456789"),
+      Value::unary(b"123456789"),
+   );
+   assert_eq!(
+      Value::unary(b"123456789101112131415161718192021"),
+      Value::unary(b"123456789101112131415161718192021"),
+   );
+   assert_eq!(
+      Value::unary(b"0"),
+      Value::Literal(0,0,Rc::new(vec![])),
+   );
+   assert_eq!(
+      Value::Literal(0,0,Rc::new(vec![])),
+      Value::unary(b"0"),
+   );
+   assert_eq!(
+      Value::unary(b"1"),
+      Value::Literal(0,1,Rc::new(vec!['0'])),
+   );
+   assert_eq!(
+      Value::Literal(0,1,Rc::new(vec!['0'])),
+      Value::unary(b"1"),
+   );
+}
+
+#[test]
 fn eq_literals() {
    assert_eq!(
       Value::Literal(0,1,Rc::new(vec!['a'])),


### PR DESCRIPTION
unary encoded is easy to represent efficiently as a BigUInt. All character indices are '0' so only string length is important.